### PR TITLE
Add RAW socket type to LwIP

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -170,6 +170,13 @@ config LWIP_UDP
 	bool "UDP support"
 	default y
 
+config LWIP_RAW
+	bool "RAW support"
+	default n
+	help
+		Enable the RAW address family (AF_RAW).  This option allows an
+		application to be able to hook into the IP layer itself.
+
 menuconfig LWIP_TCP
 	bool "TCP support"
 	default y

--- a/include/lwipopts.h
+++ b/include/lwipopts.h
@@ -121,6 +121,15 @@ void sys_free(void *ptr);
 #endif
 
 /**
+ * RAW support
+ */
+#if CONFIG_LWIP_RAW
+#define LWIP_RAW 1
+#else
+#define LWIP_RAW 0
+#endif
+
+/**
  * UDP options
  */
 #if CONFIG_LWIP_UDP


### PR DESCRIPTION
Added RAW config option into `lwipopts.h`. 
Updated `Config.uk` to reflect option addition.

Signed-off-by: Ethan Cotterell <e.cotterell@lancaster.ac.uk>