### PR TITLE
include: Add IP fragment option

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -117,6 +117,18 @@ config LWIP_IPV6
 	bool "IPv6 support"
 	default n
 
+menu "IP Configuration"
+	depends on LWIP_IPV4 || LWIP_IPV6
+
+config LWIP_IP_REASS_MAX_PBUFS
+	int "Maximum number of fragments"
+	default 10
+	help
+		This is the maximum number of IP fragments waiting to be
+		reassembled.
+
+endmenu
+
 config LWIP_UDP
 	bool "UDP support"
 	default y

--- a/include/lwipopts.h
+++ b/include/lwipopts.h
@@ -110,13 +110,14 @@ void sys_free(void *ptr);
 #if CONFIG_LWIP_IPV6
 #define LWIP_IPV6 1
 #define IPV6_FRAG_COPYHEADER 1
-
 #else
 #define LWIP_IPV6 0
 #endif
 
 #if ((!LWIP_IPV4) && (!LWIP_IPV6))
 #error No IP protocol was selected! Please choose at least one of LWIP_IPV4 and LWIP_IPV6
+#else
+#define IP_REASS_MAX_PBUFS CONFIG_LWIP_IP_REASS_MAX_PBUFS
 #endif
 
 /**
@@ -241,7 +242,8 @@ void sys_free(void *ptr);
  * this at the very last point in this configuration file.
  */
 #ifndef PBUF_POOL_SIZE
-#define PBUF_POOL_SIZE ((TCP_WND + TCP_MSS - 1) / TCP_MSS)
+#include <uk/essentials.h> /* MAX */
+#define PBUF_POOL_SIZE MAX(((TCP_WND + TCP_MSS - 1) / TCP_MSS), 2 * IP_REASS_MAX_PBUFS)
 #endif
 #ifndef PBUF_POOL_BUFSIZE
 /* smallest PBUF_POOL_BUFSIZE which satisfies TCP_WND < PBUF_POOL_SIZE * (PBUF_POOL_BUFSIZE - protocol headers) */


### PR DESCRIPTION
This patch adds a configuration menu that allows for setting IP
options whenever IPv4 or IPv6 is enabled. As a first option, the
number of IP fragments waiting to be reassembled can be configured.

Signed-off-by: Marc Rittinghaus <marc.rittinghaus@kit.edu>