### PR TITLE
Configuration: Differentiate between loopback traffic and loopback device

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -45,6 +45,15 @@ config LWIP_UNIKRAFT21X
 endchoice
 
 menu "Netif drivers"
+config LWIP_LOOPIF
+	bool "Loop interface"
+	default n
+	select LWIP_LOOPBACK
+	help
+		A driver for localhost (e.g., 127.0.0.1) networking.
+		Note: When lwIP is configured with mainloop mode, the
+		loop interface needs to be polled manually (netif_poll()).
+
 config LWIP_UKNETDEV
 	bool "Unikraft Netdev Ethernet (libuknetdev)"
 	default y
@@ -140,11 +149,13 @@ config LWIP_NETIF_STATUS_PRINT
 	help
 		Print netif status changes to standard console
 
-config LWIP_HAVE_LOOPIF
-	bool "Loopback interface"
-	default n
+config LWIP_LOOPBACK
+	bool "Loopback traffic"
+	default y
 	help
-		Enable loopback interface.
+		Support sending packets with a destination IP address
+		that is equal to the netif IP address, looping them back
+		up the stack.
 
 config LWIP_IPV4
 	bool "IPv4 support"

--- a/include/lwipopts.h
+++ b/include/lwipopts.h
@@ -62,8 +62,10 @@ void sys_free(void *ptr);
  */
 #if CONFIG_LWIP_NOTHREADS
 #define NO_SYS 1
+#define LWIP_NETIF_LOOPBACK_MULTITHREADING 0
 #else  /* CONFIG_LWIP_NOTHREADS */
 #define NO_SYS 0
+#define LWIP_NETIF_LOOPBACK_MULTITHREADING 1
 /* lightweight protection */
 #define SYS_LIGHTWEIGHT_PROT 1
 #define TCPIP_THREAD_NAME "lwip"
@@ -88,7 +90,13 @@ void sys_free(void *ptr);
 #define LWIP_NETIF_EXT_STATUS_CALLBACK 0
 #endif /* CONFIG_LWIP_NETIF_EXT_STATUS_CALLBACK */
 
-#if CONFIG_LWIP_HAVE_LOOPIF
+#if CONFIG_LWIP_LOOPBACK
+/* dest IP can be equal to netif sender IP */
+#define LWIP_NETIF_LOOPBACK 1
+#endif
+
+#if CONFIG_LWIP_LOOPIF
+/* localhost network adapter (127.0.0.1) */
 #define LWIP_HAVE_LOOPIF 1
 #endif
 


### PR DESCRIPTION
This PR enables configuring handling of loopback traffic separately from loopback device. Loopback traffic allows to send packets with a destination IP address that is equal to the netif device IP address, and looping them back up the stack.
The loopback interface provides an interface for localhost communication (127.0.0.1). The loopback interface configuration is moved under the `Netif drivers` submenu.

This PR depends on PR #9 .