### PR TITLE
sockets.c: fix crash when handling invalid/unsupported FDs

### DIFF
--- a/sockets.c
+++ b/sockets.c
@@ -538,14 +538,13 @@ int select(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds,
 					FD_CLR(i, readfds);
 					continue;
 				}
-#else
+#endif
 				LWIP_DEBUGF(SOCKETS_DEBUG,
 					    ("failed to identify socket descriptor\n"));
 				ret = -1;
 				/* Setting the errno */
 				SOCK_NET_SET_ERRNO(PTR2ERR(file));
 				goto EXIT;
-#endif
 			}
 			if (maxfd < file->sock_fd)
 				maxfd = file->sock_fd;
@@ -561,14 +560,13 @@ int select(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds,
 					FD_CLR(i, writefds);
 					continue;
 				}
-#else
+#endif
 				LWIP_DEBUGF(SOCKETS_DEBUG,
 					    ("failed to identify socket descriptor\n"));
 				ret = -1;
 				/* Setting the errno */
 				SOCK_NET_SET_ERRNO(PTR2ERR(file));
 				goto EXIT;
-#endif
 			}
 			if (maxfd < file->sock_fd)
 				maxfd = file->sock_fd;
@@ -584,14 +582,13 @@ int select(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds,
 					FD_CLR(i, exceptfds);
 					continue;
 				}
-#else
+#endif
 				LWIP_DEBUGF(SOCKETS_DEBUG,
 					    ("failed to identify socket descriptor\n"));
 				ret = -1;
 				/* Setting the errno */
 				SOCK_NET_SET_ERRNO(PTR2ERR(file));
 				goto EXIT;
-#endif
 			}
 			if (maxfd < file->sock_fd)
 				maxfd = file->sock_fd;


### PR DESCRIPTION
aee924b [0] introduce a bug where any return value of sock_net_file_get
that is an error code but *not -EBADF* will return in a crash.

Assume a situation where sock_net_file_get(i) returns an error-encoded
file that is not -EBADF (e.g., -EINVAL): that file will go through the

	if (PTR2ERR(file) == -EBADF)

check and pass it, moving on to

	if (maxfd < file->sock_fd)

where the error-encoded pointer is dereferenced, resulting in a crash.

[0] https://github.com/hlef/lib-lwip/commit/aee924ba854034f8b085a4298

Signed-off-by: Hugo Lefeuvre <hugo.lefeuvre@manchester.ac.uk>