### PR TITLE
serv.c: Add uk/essentials.h as include dependency

### DIFF
--- a/serv.c
+++ b/serv.c
@@ -36,6 +36,7 @@
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>
+#include <uk/essentials.h>
 
 struct servent *getservbyname(const char *name __unused,
 	const char *proto __unused)


### PR DESCRIPTION
This fixes build issue with undefined `__unused` symbol.

Fixes #21 