### PR TITLE
Cleanup and fix configuration options

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -287,22 +287,6 @@ menuconfig LWIP_SOCKET
 	default y
 
 if LWIP_SOCKET
-	config LWIP_SOCKET_SELECT_GENERIC_FDS
-		bool "Use select() with any file descriptor type"
-		depends on HAVE_LIBC
-		default y
-		help
-			lwip's select() implementation supports only sockets. This
-			configuration option makes it possible to use other file descriptor
-			types as well, even though they are not supported by lwip.
-
-	config LWIP_SOCKET_PPOLL
-		bool "Enable ppoll()"
-		depends on HAVE_LIBC
-		default y
-		help
-			Enable ppoll() implementation.
-
 	config LWIP_UDP_RECVMBOX_FACTOR
 		int "Factor for UDP recvmbox"
 		depends on LWIP_UDP

--- a/include/lwipopts.h
+++ b/include/lwipopts.h
@@ -154,6 +154,10 @@ void sys_free(void *ptr);
 #define TCP_CALCULATE_EFF_SEND_MSS 1
 #define IP_FRAG 0
 
+#ifdef CONFIG_LWIP_TCP_KEEPALIVE
+#define LWIP_TCP_KEEPALIVE 1
+#endif /* CONFIG_LWIP_TCP_KEEPALIVE */
+
 #if CONFIG_LWIP_WND_SCALE
 /*
  * Maximum window and scaling factor

--- a/include/lwipopts.h
+++ b/include/lwipopts.h
@@ -158,6 +158,10 @@ void sys_free(void *ptr);
 #define LWIP_TCP_KEEPALIVE 1
 #endif /* CONFIG_LWIP_TCP_KEEPALIVE */
 
+#ifdef CONFIG_LWIP_TCP_TIMESTAMPS
+#define LWIP_TCP_TIMESTAMPS 1
+#endif /* CONFIG_LWIP_TCP_TIMESTAMPS */
+
 #if CONFIG_LWIP_WND_SCALE
 /*
  * Maximum window and scaling factor


### PR DESCRIPTION
The corresponding Unikraft config has a `CONFIG_` prefix that won't be picked up by the LWIP source code.
This also removes two unused configuration options.