### PR TITLE
Adapt forced polling mode to uknetdev flag rename

### DIFF
--- a/uknetdev.c
+++ b/uknetdev.c
@@ -477,7 +477,7 @@ err_t uknetdev_init(struct netif *nf)
 		return ERR_IF;
 #if CONFIG_LWIP_UKNETDEV_POLLONLY
 	/* Unset receive interrupt support: We force polling mode */
-	lwip_data->dev_info.features &= ~UK_FEATURE_RXQ_INTR_AVAILABLE;
+	lwip_data->dev_info.features &= ~UK_NETDEV_F_RXQ_INTR;
 #endif /* CONFIG_LWIP_UKNETDEV_POLLONLY */
 	lwip_data->pkt_a = a;
 


### PR DESCRIPTION
The rxq interrupt flag was renamed in unikraft some time ago [1]. This adapts liblwip to this change.

[1]: https://github.com/unikraft/unikraft/commit/bf6ebd2b49728278b6f19ef6ef060d86ca166675

Signed-off-by: Marco Schlumpp <marco.schlumpp@gmail.com>