### PR TITLE
Fix packet leak on uknetdev_output()

### DIFF
--- a/uknetdev.c
+++ b/uknetdev.c
@@ -177,7 +177,7 @@ static err_t uknetdev_output(struct netif *nf, struct pbuf *p)
 	do {
 		ret = uk_netdev_tx_one(dev, 0, nb);
 	} while (uk_netdev_status_notready(ret));
-	if (unlikely(ret < 0)) {
+	if (unlikely((ret & UK_NETDEV_STATUS_SUCESS) == 0)) {
 		LWIP_DEBUGF(NETIF_DEBUG,
 			    ("%s: %c%c%u: Failed to send %"PRIu16" bytes\n",
 			     __func__, nf->name[0], nf->name[1], nf->num,


### PR DESCRIPTION
uk_netdev_tx_one() returns at least UK_NETDEV_STATUS_SUCESS if the packet was consumed. It might still return 0 if there was no space in the transmit ring, in that case the packet is not consumed and it's the caller's responsability to deal with it.

Observe virtio_net.c:445, virtio_netdev_xmit():
```
           } else if (rc == -ENOSPC) {
                    uk_pr_debug("No more descriptor available\n");
                    /**
                     * Remove header before exiting because we could not send
                     */
                    uk_netbuf_header(pkt, -header_sz);
    ...
            return (status) /* which is zero here */
```
I find the API a bit confusing, it would make more sense to not return zero from netdev, but it's properly documented:
```
 * @return
 *   - (>=0): Positive value with status flags
 *     - UK_NETDEV_STATUS_SUCCESS: `pkt` was successfully put to the transmit
 *        queue. Whenever this flag is not set, there was no space left on the
 *        transmit queue to send `pkt`.
```
Untested, caught just by reading the virtio driver, hope I'm not missing anything.