### PR TITLE
Modify `atomic.h` import line to accomodate plat re-arch

### DIFF
--- a/uknetdev.c
+++ b/uknetdev.c
@@ -50,7 +50,7 @@
 #include "lwip/ethip6.h"
 #include "netif/etharp.h"
 #include "netif/ethernet.h"
-#include <uk/arch/atomic.h>
+#include <uk/atomic.h>
 
 #include <uk/essentials.h>
 


### PR DESCRIPTION
As part of the current `re-arch` initiative, the location and structure of `atomic.h` has changed. This PR reflects that. 

Relevant PR in `unikraft` repo [950](https://github.com/unikraft/unikraft/pull/950)