### PR TITLE
Adapt to new auxiliary stack argument of `libuksched` API

### DIFF
--- a/threads.c
+++ b/threads.c
@@ -53,7 +53,7 @@ sys_thread_t sys_thread_new(const char *name, lwip_thread_fn thread, void *arg,
 
 	t = uk_sched_thread_create_fn1(s,
 				       (uk_thread_fn1_t) thread, arg,
-				       (size_t) stacksize,
+				       (size_t) stacksize, 0,
 				       false,
 				       false,
 				       name,


### PR DESCRIPTION
Now all thread creation related functions also require an auxiliary stack-related argument: either a pointer to it or its desired length.

Thus, provide argument 0 for length of auxiliary stack, allowing the allocation to use the default length.

Depends-on: [#1174](https://github.com/unikraft/unikraft/pull/1174)