### PR TITLE
Silence warning on arithmetic operation on socket flags (corrected)

### DIFF
--- a/sockets.c
+++ b/sockets.c
@@ -80,7 +80,7 @@ lwip_posix_socket_create(struct posix_socket_driver *d, int family, int type,
 	int flags, rc;
 
 	/* Blocking is handled by posix-socket */
-	flags = type & SOCK_FLAGS | SOCK_NONBLOCK;
+	flags = (type & SOCK_FLAGS) | SOCK_NONBLOCK;
 	type = type & ~SOCK_FLAGS;
 
 	lwip_fd = lwip_socket(family, type, protocol);

--- a/sockets.c
+++ b/sockets.c
@@ -80,7 +80,7 @@ lwip_posix_socket_create(struct posix_socket_driver *d, int family, int type,
 	int flags, rc;
 
 	/* Blocking is handled by posix-socket */
-	flags = type & (SOCK_FLAGS | SOCK_NONBLOCK);
+	flags = type & SOCK_FLAGS | SOCK_NONBLOCK;
 	type = type & ~SOCK_FLAGS;
 
 	lwip_fd = lwip_socket(family, type, protocol);


### PR DESCRIPTION
`b994307` introduced a fix for a GCC warning that turned out to be incorrect. Revert and push correct fix.