### PR TITLE
Various smaller fixes

### DIFF
--- a/include/lwipopts.h
+++ b/include/lwipopts.h
@@ -107,6 +107,7 @@ void sys_free(void *ptr);
 /**
  * ARP options
  */
+#define ARP_QUEUEING 1
 #define MEMP_NUM_ARP_QUEUE 256
 #define ETHARP_SUPPORT_STATIC_ENTRIES 1
 

--- a/sockets.c
+++ b/sockets.c
@@ -209,6 +209,9 @@ lwip_posix_socket_getsockopt(posix_sock *file, int level,
 	return ret;
 }
 
+#define LINUX_SOL_TCP 6
+#define LINUX_TCP_FASTOPEN 23
+
 static int
 lwip_posix_socket_setsockopt(posix_sock *file, int level,
 			     int optname, const void *optval, socklen_t optlen)
@@ -219,6 +222,11 @@ lwip_posix_socket_setsockopt(posix_sock *file, int level,
 	lwip_fd = _lwip_getfd(file);
 	UK_ASSERT(lwip_fd >= 0);
 
+	if ((level == LINUX_SOL_TCP && optname == LINUX_TCP_FASTOPEN) ||
+	    (level == SOL_IP && optname == IP_RECVERR)) {
+		/* Ignore stuff that LWIP doesn't support */
+		return 0;
+	}
 	ret = lwip_setsockopt(lwip_fd, level, optname, optval, optlen);
 	if (unlikely(ret < 0))
 		ret = -errno;


### PR DESCRIPTION
These were primarily motivated by the glibc DNS resolver. The resolver code relies on being able to successfully set socket options, which are not available on LWIP.
Also the resolver sends multiple packets at once, which requires queuing packets until the initial ARP request is answered.