### PR TITLE
Option to wait for DHCP and fail without netifs

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -277,6 +277,21 @@ config LWIP_DHCP
 		query the IPv4 addresses for the found devices from a DHCP
 		server on network.
 
+if LWIP_DHCP
+config LWIP_WAITIFACE
+	bool "Wait for 1st interface"
+	depends on LWIP_AUTOIFACE
+	select LWIP_NETIF_EXT_STATUS_CALLBACK
+	select LIBUKLOCK
+	select LIBUKLOCK_SEMAPHORE
+
+config LWIP_WAITIFACE_TO
+	int "Wait timeout (seconds, 0 = forever)"
+	range 0 300
+	default 5
+	depends on LWIP_WAITIFACE
+endif # LWIP_DHCP
+
 menuconfig LWIP_DNS
 	bool "DNS Resolver"
 	default y

--- a/Config.uk
+++ b/Config.uk
@@ -100,6 +100,10 @@ config LWIP_AUTOIFACE
 		Automatically attach found network devices to the stack
 		during initialization.
 
+config LWIP_FAILNOIFACE
+	bool "Fail boot without netifs"
+	depends on LWIP_AUTOIFACE
+
 choice
 	prompt "Operation mode"
 	default LWIP_THREADS


### PR DESCRIPTION
This PR adds two configuration options that let Unikraft to wait for DHCP responses and/or fail the boot without networking interface.