### PR TITLE
Prepare lwip to provde DNS functions to native musl

### DIFF
--- a/include/lwipopts.h
+++ b/include/lwipopts.h
@@ -260,6 +260,15 @@ void sys_free(void *ptr);
 #define DNS_TABLE_SIZE CONFIG_LWIP_DNS_TABLE_SIZE
 #define DNS_LOCAL_HOST_LIST 1
 #define DNS_LOCAL_HOSTLIST_IS_DYNAMIC 1
+
+#if CONFIG_LIBMUSL_NETWORK
+/* lwip should not declare its own data types */
+#define LWIP_DNS_API_DECLARE_H_ERRNO  0
+#define LWIP_DNS_API_DEFINE_ERRORS    0
+#define LWIP_DNS_API_DEFINE_FLAGS     0
+#define LWIP_DNS_API_DECLARE_STRUCTS  0
+#include <netdb.h>
+#endif /* CONFIG_LIBMUSL_NETWORK */
 #endif /* LWIP_DNS */
 
 /**

--- a/include/lwipopts.h
+++ b/include/lwipopts.h
@@ -406,6 +406,7 @@ void sys_free(void *ptr);
 #if CONFIG_LWIP_SERVICE_DEBUG
 #define ETHARP_DEBUG     LWIP_DBG_ON
 #define DNS_DEBUG        LWIP_DBG_ON
+#define NETDB_DEBUG      LWIP_DBG_ON
 #define AUTOIP_DEBUG     LWIP_DBG_ON
 #define DHCP_DEBUG       LWIP_DBG_ON
 #define ICMP_DEBUG       LWIP_DBG_ON


### PR DESCRIPTION
This PR prepares lwip so that musl can directly use lwip's DNS functionality to implement DNS hostname resolution.