### PR TITLE
Set system hostname when initializing interface

### DIFF
--- a/uknetdev.c
+++ b/uknetdev.c
@@ -34,6 +34,7 @@
 #include <uk/config.h>
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 
 #include <uk/alloc.h>
 #include <uk/print.h>
@@ -699,8 +700,12 @@ struct netif *uknetdev_addif(struct uk_netdev *n
 		return NULL;
 	}
 
-	if (hostname)
+	if (hostname) {
 		netif_set_hostname(nf, hostname);
+#if CONFIG_LIBPOSIX_SYSINFO
+		sethostname(hostname, strlen(hostname));
+#endif /* CONFIG_LIBPOSIX_SYSINFO */
+	}
 
 	return ret;
 }


### PR DESCRIPTION
### Description of Changes

This change makes lwip set the system hostname to the one it receives during initialization, using the `sethostname` library call.

Depends on the following core Unikraft PR:
- https://github.com/unikraft/unikraft/pull/1307

### Testing

Syscalls such as `uname` or `gethostname` should return the same hostname as passed to lwip through the `netdev.ip` kernel parameter.