### PR TITLE
Expose LWIP_SO_RCVBUF config and set on by default

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -182,6 +182,12 @@ config LWIP_NETIF_STATUS_PRINT
 	help
 		Print netif status changes to standard console
 
+config LWIP_RCVBUF
+	bool "Use receive buffers"
+	default y
+	help
+		Use receive buffers, enabling the SO_RCVBUF socket option and FIONREAD ioctl
+
 config LWIP_LOOPBACK
 	bool "Loopback traffic"
 	default y

--- a/include/lwipopts.h
+++ b/include/lwipopts.h
@@ -214,6 +214,10 @@ void sys_free(void *ptr);
 #define LWIP_SOCKET 0
 #endif
 
+#if CONFIG_LWIP_RCVBUF
+#define LWIP_SO_RCVBUF 1
+#endif
+
 #if LWIP_SOCKET
 #if CONFIG_HAVE_LIBC
 /* Stop lwip to provide ioctl constants */


### PR DESCRIPTION
### Description of changes
This change exposes the LWIP_SO_RCVBUF config option through the Unikraft Kconfig, configuring whether lwip should use receive buffers. Receive buffers enable support for the SO_RCVBUF socket option as well as ioctl(FIONREAD).
This option is enabled by default to provide the most compatibility.

### Testing
On `staging`, `setsockopt(SO_RCVBUF)` or `ioctl(FIONREAD)` on a LWIP socket will error out with `ENOSYS`.
After this patch, these functions are available depending on the `CONFIG_LWIP_RCVBUF` Kconfig option.