### PR TITLE
Ignore SO_LINGER socket option

### DIFF
--- a/sockets.c
+++ b/sockets.c
@@ -223,7 +223,8 @@ lwip_posix_socket_setsockopt(posix_sock *file, int level,
 	UK_ASSERT(lwip_fd >= 0);
 
 	if ((level == LINUX_SOL_TCP && optname == LINUX_TCP_FASTOPEN) ||
-	    (level == SOL_IP && optname == IP_RECVERR)) {
+	    (level == SOL_IP && optname == IP_RECVERR) ||
+	    (level == SOL_SOCKET && optname == SO_LINGER)) {
 		/* Ignore stuff that LWIP doesn't support */
 		return 0;
 	}


### PR DESCRIPTION
Stub the SO_LINGER socket option. This would be used to ensure that whenever closing a socket we will wait for all message queues to finish flushing or until the linger timeout expires, essentially making the closing of the socket block for at most the preset timeout.