### PR TITLE
lwip: Provide config option for SO_LINGER and enable by default

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -192,6 +192,13 @@ config LWIP_RCVBUF
 	help
 		Use receive buffers, enabling the SO_RCVBUF socket option and FIONREAD ioctl
 
+config LWIP_LINGER
+	bool "Linger on close()"
+	default y
+	help
+		Enables support of the SO_LINGER socket option that allows delaying close()
+		if data still available in the socket.
+
 config LWIP_LOOPBACK
 	bool "Loopback traffic"
 	default y

--- a/include/lwipopts.h
+++ b/include/lwipopts.h
@@ -219,6 +219,10 @@ void sys_free(void *ptr);
 #define LWIP_SO_RCVBUF 1
 #endif
 
+#if CONFIG_LWIP_LINGER
+#define LWIP_SO_LINGER 1
+#endif
+
 #if LWIP_SOCKET
 #if CONFIG_HAVE_LIBC
 /* Stop lwip to provide ioctl constants */


### PR DESCRIPTION
Add a Kconfig option that controls support for `SO_LINGER`, and enable by default. SO_LINGER allows delaying close() by a specified timeout when data is still available in the socket.

Supersedes: #51 (CC: @mogasergiu)