### PR TITLE
sockets.c: Use size_t for iovec length

### DIFF
--- a/sockets.c
+++ b/sockets.c
@@ -343,7 +343,7 @@ lwip_posix_socket_sendto(posix_sock *file, const void *buf,
 
 static ssize_t
 lwip_posix_socket_read(posix_sock *file, const struct iovec *iov,
-		       int iovcnt)
+		       size_t iovcnt)
 {
 	int lwip_fd;
 	ssize_t ret;
@@ -360,7 +360,7 @@ lwip_posix_socket_read(posix_sock *file, const struct iovec *iov,
 
 static ssize_t
 lwip_posix_socket_write(posix_sock *file, const struct iovec *iov,
-		       int iovcnt)
+			size_t iovcnt)
 {
 	int lwip_fd;
 	ssize_t ret;


### PR DESCRIPTION
This change updates the lwip socket read/write ops to use unsigned size_t for the length of the passed-in iovec.
In response to https://github.com/unikraft/unikraft/pull/1580.

The internal lwip read/write functions still use int, and simply package it into struct msghdr, which is size_t once again. If overflow is a concern we should fix it with a build patch.