### PR TITLE
Redefine MAX macro with ternary operator

### DIFF
--- a/include/lwipopts.h
+++ b/include/lwipopts.h
@@ -289,7 +289,7 @@ void sys_free(void *ptr);
  * this at the very last point in this configuration file.
  */
 #ifndef PBUF_POOL_SIZE
-#include <uk/essentials.h> /* MAX */
+#define MAX(a,b) ((a)>(b) ? (a) : (b))
 #define PBUF_POOL_SIZE MAX(((TCP_WND + TCP_MSS - 1) / TCP_MSS), 2 * IP_REASS_MAX_PBUFS)
 #endif
 #ifndef PBUF_POOL_BUFSIZE


### PR DESCRIPTION
This PR fixes a build failure (see #63 and #[1308](https://github.com/unikraft/unikraft/issues/1308)) when using `lib-lwip` with Memory Pools allocation mode by redefining the MAX macro with a ternary operator in `lwipopts.h`

The `MAX` macro from `<uk/essentials.h>` uses a GNU statement expression (`({ ... })`), which is not valid in preprocessor directives like `#if`. This caused compilation errors in `init.c` and `memp.c`.