### PR TITLE
Check return value of uk_random_bytes()

### DIFF
--- a/include/arch/cc.h
+++ b/include/arch/cc.h
@@ -59,10 +59,14 @@
 #define ETH_PAD_SIZE 0
 
 /* rand */
-#define LWIP_RAND() ({				\
-	__u32 x;				\
-	uk_random_fill_buffer(&x, sizeof(x));	\
-	x;					\
+#define LWIP_RAND() ({						\
+	int res;						\
+	__u32 x;						\
+	res = uk_random_fill_buffer(&x, sizeof(x));		\
+	if (unlikely(res))					\
+		UK_CRASH("Could not obtain randomness (%d)",	\
+			 res);					\
+	x;							\
 })
 
 /* compiler hints for packing lwip's structures */


### PR DESCRIPTION
lwip provides the LWIP_RAND() macro to obtain random numbers for purposes like TCP ISNs, source port selection, IP fragment IDs, etc The default implementation [implements the macro using rand()](https://github.com/lwip-tcpip/lwip/blob/master/src/include/lwip/arch.h#L72), which is [implements a pseudo-rng](https://man7.org/linux/man-pages/man3/rand.3.html). Furthermore, the macro assumes no error checking.

Unikraft's implementation uses libukarandom's uk_random_bytes() to provide secure randomness. That function may fail on reseed, so it's is critical to check its return value. Add a check within the macro, and treat failures as fatal.