### PR TITLE
patches: Remove FD_SETSIZE restriction on sockets

### DIFF
--- a/patches/0013-allow-more-sockets-than-select.patch
+++ b/patches/0013-allow-more-sockets-than-select.patch
@@ -1,0 +1,13 @@
+diff --git a/src/include/lwip/sockets.h b/src/include/lwip/sockets.h
+index d70d36c4..233ecc8d 100644
+--- a/src/include/lwip/sockets.h
++++ b/src/include/lwip/sockets.h
+@@ -483,8 +483,6 @@ typedef struct fd_set
+   unsigned char fd_bits [(FD_SETSIZE+7)/8];
+ } fd_set;
+ 
+-#elif FD_SETSIZE < (LWIP_SOCKET_OFFSET + MEMP_NUM_NETCONN)
+-#error "external FD_SETSIZE too small for number of sockets"
+ #else
+ #define LWIP_SELECT_MAXNFDS FD_SETSIZE
+ #endif /* FD_SET */


### PR DESCRIPTION
This change adds a patch that removes the restriction that all socket fds must fit within the fdset used by select() -- which in practice can be much lower than the total available file descriptors on the system. This limitation of select() has long been worked around by workloads using newer APIs such as ppoll() or epoll(), and as such this strict limitation on lwip is not warranted.