### PR TITLE
Config.uk, lwipopts.h: Expose TCP_MSL as configurable option

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -267,6 +267,17 @@ config LWIP_NUM_TCPCON
 config LWIP_NUM_TCPLISTENERS
 	int "Maximum number of simultaneous TCP listeners"
 	default 64
+
+config LWIP_TCP_MSL
+	int "Maximum segment lifetime (ms)"
+	default 60000
+	help
+	  The maximum segment lifetime in milliseconds, used to determine
+	  the TIME_WAIT timeout (2 * TCP_MSL). Connections remain in
+	  TIME_WAIT state for this duration after closing, consuming
+	  resources. Lower values allow faster connection recycling at the
+	  cost of potential duplicate packet issues. Default is 60000 (60s),
+	  resulting in a 120s TIME_WAIT.
 endif
 
 config LWIP_ICMP

--- a/include/lwipopts.h
+++ b/include/lwipopts.h
@@ -162,6 +162,7 @@ void sys_free(void *ptr);
 
 #if LWIP_TCP
 #define TCP_MSS CONFIG_LWIP_TCP_MSS
+#define TCP_MSL ((u32_t)CONFIG_LWIP_TCP_MSL)
 #define TCP_CALCULATE_EFF_SEND_MSS 1
 #define IP_FRAG 0
 


### PR DESCRIPTION
I was investigating this [issue (catalog-core #77)](https://github.com/unikraft/catalog-core/issues/77) about nginx's poor and unstable performance under repeated stress tests and traced the root cause to `lwIP`'s `TIME_WAIT`  behavior.

When benchmarking nginx with `wrk -t 14 -d1m -c 30` repeatedly, throughput alternates between `~5,000 req/s and ~150 req/s`. This happens because when connections close, they enter `TIME_WAIT` for `2 * TCP_MSL = 120` seconds. With `MEMP_MEM_MALLOC=1` (heap mode), pool limits like `MEMP_NUM_TCP_PCB` don't actually bound allocations, so increasing `LWIP_NUM_TCPCON` has no effect. The real issue is that `TIME_WAIT PCBs` accumulate and stall new connection establishment in the tcpip thread. I observed 20-30 second delays on TCP handshakes during "bad" runs.

`lwIP` already defines `TCP_MSL` with an `#ifndef` guard in `tcp_priv.h`, so it's designed to be overridable. This PR exposes it as a Kconfig option (`LWIP_TCP_MSL`), keeping the default at 60000ms so existing behavior is unchanged.

I tested with nginx using TCP_MSL=5000 (TIME_WAIT = 10s):

| Run | Default (TCP_MSL=60s) | TCP_MSL=5s |
|-----|----------------------|------------|
| 1   | 5,303 req/s          | 27,645 req/s |
| 2   | 193 req/s            | 19,862 req/s |
| 3   | 3,170 req/s          | 23,299 req/s |
| 4   | 164 req/s            | 24,313 req/s |


Verified that c-http, cpp-http, click, and nginx all build correctly with the new option at the default value.