### PR TITLE
netlink: fix invalid netif address check

### DIFF
--- a/netlink.c
+++ b/netlink.c
@@ -342,7 +342,7 @@ static int reply_getaddr_if(struct nl_ctx *ctx, struct netif *netif,
 
 #if LWIP_IPV6
 	/* With dual-stack, addresses get a type */
-	if (netif->address.type != IPADDR_TYPE_V4)
+	if (!IP_IS_V4(&netif->ip_addr))
 		return 0; /* no IPv4 address */
 #endif /* LWIP_IPV6 */
 


### PR DESCRIPTION
### Tested On:
- arm64 Ubuntu 24.04, gcc 13.3;
- x86_64 ArchLinux 7.0.5-arch1-1, gcc 16.1 (extra flags: `-std=gnu11`)

### Description:
`struct netif` does not contain an `address` member in lwIP.

Maybe we can use `IP_IS_V4(&netif->ip_addr)` instead.

This restores compatibility with current lwIP versions and fixes the compilation error:

```
catalog-core/repos/libs/lwip/netlink.c: In function ‘reply_getaddr_if’:
catalog-core/repos/libs/lwip/netlink.c:345:18: error: ‘struct netif’ has no member named ‘address’
  345 |         if (netif->address.type != IPADDR_TYPE_V4)
      |                  ^~
```